### PR TITLE
Corrected condition when resource URI is empty or null

### DIFF
--- a/app/src/main/java/com/example/bluromatic/workers/BlurWorker.kt
+++ b/app/src/main/java/com/example/bluromatic/workers/BlurWorker.kt
@@ -50,7 +50,7 @@ class BlurWorker(ctx: Context, params: WorkerParameters) : CoroutineWorker(ctx, 
             delay(DELAY_TIME_MILLIS)
 
             return@withContext try {
-                require(!resourceUri.isNullOrBlank()) {
+                require(resourceUri.isNullOrBlank()) {
                     val errorMessage =
                         applicationContext.resources.getString(R.string.invalid_input_uri)
                     Log.e(TAG, errorMessage)


### PR DESCRIPTION
Corrected condition when resource URI is empty or null.
<img width="956" alt="285193082-29ee4ff7-471b-4f63-b14e-44c6fb1230e3" src="https://github.com/google-developer-training/basic-android-kotlin-compose-training-workmanager/assets/2944296/9676c73e-b666-4485-95c0-1db2b2bec1cb">
