### PR TITLE
Add save image logic for API 29(Q) compatibility.

### DIFF
--- a/app/src/main/java/com/example/bluromatic/domain/CreateImageUriUseCase.kt
+++ b/app/src/main/java/com/example/bluromatic/domain/CreateImageUriUseCase.kt
@@ -1,0 +1,30 @@
+package com.example.bluromatic.domain
+
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.net.Uri
+import android.provider.MediaStore
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Create imageUri.
+ */
+@RequiresApi(29)
+class CreateImageUriUseCase {
+    suspend operator fun invoke(resolver: ContentResolver, filename: String): Uri? {
+        return withContext(Dispatchers.IO) {
+            val imageCollection =
+                MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+            val values = ContentValues().apply {
+                put(MediaStore.Images.Media.DISPLAY_NAME, filename)
+                put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/Blur-O-Matic")
+                put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+            val imageUri = resolver.insert(imageCollection, values)
+            imageUri
+        }
+    }
+}

--- a/app/src/main/java/com/example/bluromatic/domain/SaveImageUseCase.kt
+++ b/app/src/main/java/com/example/bluromatic/domain/SaveImageUseCase.kt
@@ -1,0 +1,38 @@
+package com.example.bluromatic.domain
+
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.graphics.Bitmap
+import android.net.Uri
+import android.provider.MediaStore
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val TAG = "SaveImage"
+
+/**
+ * Save image into MediaStore.
+ */
+class SaveImageUseCase {
+    suspend operator fun invoke(
+        resolver: ContentResolver,
+        contentUri: Uri?,
+        bitmap: Bitmap,
+    ) = withContext(Dispatchers.IO) {
+        try {
+            contentUri?.let { contentUri ->
+                resolver.openOutputStream(contentUri, "w")?.use { outputStream ->
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, 85, outputStream)
+                }
+                val values = ContentValues().apply {
+                    put(MediaStore.Images.Media.IS_PENDING, 0)
+                }
+                resolver.update(contentUri, values, null, null)
+            }
+        } catch (e: Throwable) {
+            Log.e(TAG, "Error occurs $e")
+            throw e
+        }
+    }
+}


### PR DESCRIPTION
API 29 needs to use a resolver.insert method.
Fix #33 